### PR TITLE
FIX: Return time variable in UTC instead of local time

### DIFF
--- a/pysp2/io/read_sp2b.py
+++ b/pysp2/io/read_sp2b.py
@@ -119,7 +119,7 @@ def read_sp2(file_name, debug=False, arm_convention=True):
         diff_epoch_1904 = (
             datetime(1970, 1, 1) - datetime(1904, 1, 1)).total_seconds()
         UTCdatetime = np.array([
-            datetime.fromtimestamp(x - diff_epoch_1904) for x in UTCtime])
+            datetime.utcfromtimestamp(x - diff_epoch_1904) for x in UTCtime])
 
         DateTimeWave = (dt - datetime(1904, 1, 1)).total_seconds() + TimeWave
 


### PR DESCRIPTION
Fixes issue #34. The time variable in the particle-level data was being returned in the machine's local time instead of UTC. This does not affect any of the downstream processing, as the time variable is not used for any of the mass or particle size distribution calculations.