### PR TITLE
FIX: Correctly handle particles > size bins

### DIFF
--- a/pysp2/__init__.py
+++ b/pysp2/__init__.py
@@ -9,4 +9,4 @@ from . import util
 from . import vis
 from . import testing
 
-__version__ = "1.3.0"
+__version__ = "1.3.1"

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ LICENSE = 'BSD'
 PLATFORMS = "Linux, Windows, OSX"
 MAJOR = 1
 MINOR = 3
-MICRO = 0
+MICRO = 1
 
 #SCRIPTS = glob.glob('scripts/*')
 #TEST_SUITE = 'nose.collector'


### PR DESCRIPTION
Fixing an issue where errors were being thrown if there were particles larger than the size bins. This error cropped up during the latest update to 1.3.0. In addition, there is a better check for a valid OneOfEvery flag.