### PR TITLE
PySP2 ver. 1.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ LICENSE = 'BSD'
 PLATFORMS = "Linux, Windows, OSX"
 MAJOR = 1
 MINOR = 3
-MICRO = 1
+MICRO = 2
 
 #SCRIPTS = glob.glob('scripts/*')
 #TEST_SUITE = 'nose.collector'


### PR DESCRIPTION
Update PySP2 to version 1.3.2 with the hotfix for the newest NumPy release.