### PR TITLE
FIX: Size distributions were only including oversize particles!

### DIFF
--- a/pysp2/__init__.py
+++ b/pysp2/__init__.py
@@ -9,4 +9,4 @@ from . import util
 from . import vis
 from . import testing
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"

--- a/pysp2/util/particle_properties.py
+++ b/pysp2/util/particle_properties.py
@@ -222,26 +222,27 @@ def process_psds(particle_ds, hk_ds, config, deltaSize=0.005, num_bins=199, avg_
         the_particles = np.logical_and.reduce((parts_time, scatter_accept))
         # Remove particles above max size
         the_particles_scat = np.logical_and.reduce(
-            (the_particles, ScatDiaBC50 > SpecSizeBins[-1] + deltaSize / 2))
+            (the_particles, ScatDiaBC50 < SpecSizeBins[-1] + deltaSize / 2))
         ind = np.searchsorted(SpecSizeBins+deltaSize / 2,
                               ScatDiaBC50[the_particles_scat], side='right')
+        
         # Remove oversize particles
-        np.add.at(ScatNumEnsembleBC[t,:], ind+1, OneOfEvery)
+        np.add.at(ScatNumEnsembleBC[t,:], ind, OneOfEvery)
         the_particles_scat = np.logical_and.reduce(
-            (the_particles, ScatDiaSO4 > SpecSizeBins[-1] + deltaSize / 2))
+            (the_particles, ScatDiaSO4 < SpecSizeBins[-1] + deltaSize / 2))
         ind = np.searchsorted(SpecSizeBins+deltaSize / 2, ScatDiaSO4[the_particles_scat], side='right')
         # Remove oversize particles
-        np.add.at(ScatNumEnsemble[t,:], ind+1, OneOfEvery)
-        np.add.at(ScatMassEnsemble[t,:], ind+1, OneOfEvery * ScatMassSO4[the_particles_scat])
+        np.add.at(ScatNumEnsemble[t,:], ind, OneOfEvery)
+        np.add.at(ScatMassEnsemble[t,:], ind, OneOfEvery * ScatMassSO4[the_particles_scat])
         
         the_particles = np.logical_and.reduce((parts_time, incand_accept))
         the_particles_incan = np.logical_and.reduce(
-            (the_particles, SizeIncandOnly > SpecSizeBins[-1] + deltaSize / 2))
+            (the_particles, SizeIncandOnly < SpecSizeBins[-1] + deltaSize / 2))
         ind = np.searchsorted(SpecSizeBins+deltaSize / 2, 
                               SizeIncandOnly[the_particles_incan], side='right')
         # Remove oversize particles
-        np.add.at(IncanNumEnsemble[t,:], ind+1, OneOfEvery)
-        np.add.at(IncanMassEnsemble[t,:], ind+1, OneOfEvery * sootMass[the_particles_incan])
+        np.add.at(IncanNumEnsemble[t,:], ind, OneOfEvery)
+        np.add.at(IncanMassEnsemble[t,:], ind, OneOfEvery * sootMass[the_particles_incan])
         
             
         scat_parts = np.logical_and(scatter_accept, parts_time)

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ LICENSE = 'BSD'
 PLATFORMS = "Linux, Windows, OSX"
 MAJOR = 1
 MINOR = 3
-MICRO = 2
+MICRO = 3
 
 #SCRIPTS = glob.glob('scripts/*')
 #TEST_SUITE = 'nose.collector'


### PR DESCRIPTION
In the latest version the size distributions were only including oversize particles. This error only affects PSDs generated by PySP2 1.3.2. I am releasing version 1.3.3.